### PR TITLE
use `steps_per_epoch` in LR Scheduler instead of `steps_per_checkpoint`

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1002,7 +1002,7 @@ class Trainer(BaseTrainer):
                 self.scheduler = LRScheduler(
                     self.config.learning_rate_scheduler,
                     self.optimizer,
-                    steps_per_checkpoint=final_steps_per_checkpoint,
+                    steps_per_checkpoint=self.steps_per_epoch,
                     total_steps=self.total_steps,
                 )
 


### PR DESCRIPTION
This will ensure of lr scheduler per epoch instead of per step count